### PR TITLE
Maybe error for "batch's y parts"?

### DIFF
--- a/docs/abbr.md
+++ b/docs/abbr.md
@@ -83,7 +83,7 @@ Note that there are always exceptions, especially when we try to comply with the
 |                  | number of classes                   | c              |                                                  |
 |                  | batch                               | b              |                                                  |
 |                  | batch's x parts                     | xb             |                                                  |
-|                  | batch's y parts                     | xy             |                                                  |
+|                  | batch's y parts                     | yb             |                                                  |
 |                  | batch size                          | bs             |                                                  |
 |                  | multiple targets                    | multi          | is_multi                                         |
 |                  | regression                          | reg            | is_reg                                           |


### PR DESCRIPTION
I guess "batch's y parts" should be yb (and not xy)?
Best regards
Michael
PS: I did not found the file for "Contributing to the documentation" but  I hope the pull request helps.